### PR TITLE
Fixed link to Julia workshop

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ The following Julia files are provided:
 
     We recommend users being familiar with Julia syntax, especially variables and types.
 
-    The formal requirements are the [Julia Syntax Workshop](https://github.com/PumasAI-Labs/Julia-Syntax) and its pre-requisites.
+    The formal requirements are the [Julia Syntax Workshop](https://pumasai-labs.github.io/Julia-Workshop/) and its pre-requisites.
 
 ## Schedule
 


### PR DESCRIPTION
The previous link was pointing to the GitHub repository and wasn't working as it was probably written before we decided to combine all Julia workshops.